### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -24,5 +24,5 @@
    "authors" : [
       "Jonathan Stowe <jns+gh@gellyfish.co.uk>"
    ],
-   "license" : "perl"
+   "license" : "Artistic-2.0"
 }


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license